### PR TITLE
Update moduleResolution in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
         "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true,
         "allowSyntheticDefaultImports": false,
-        "removeComments": true
+        "removeComments": true,
+        "moduleResolution": "node"
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
When trying to add new modules we were getting an issue where typescript
wasn't able to find them in the local node_modules folder, even though
they were there.

The reason is that the moduleResoluion was defaulting to 'classic' mode,
so in this PR we force it to 'node' which makes it check the node_modules
folder.